### PR TITLE
fix: prevent error when no user plugin directory is present

### DIFF
--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -85,6 +85,14 @@ pub(super) async fn spawn_reconciler_blocking(app_state: &AppHandle<Wry>) -> () 
         }
     }
 
+    // Check that the Plugin Dir exists. If it doesn't, create it.
+    if !user_plugin_dir.exists() {
+        info!(
+            "User Plugin Directory doesn't exist yet. Attempting to create directory at {}",
+            user_plugin_dir.display()
+        );
+        std::fs::create_dir_all(&user_plugin_dir).unwrap();
+    }
     watcher
         .watch(&user_plugin_dir, notify::RecursiveMode::Recursive)
         .unwrap();


### PR DESCRIPTION
This fix introduces a check for the user plugin's existence. If it's missing, the Backend will recursively create folders until the plugin folder is created